### PR TITLE
Use version pattern as in other spring-boot project

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add the following to your `pom.xml`
 <dependency>
     <groupId>org.zalando</groupId>
     <artifactId>aws-support-spring-boot-starter</artifactId>
-    <version>${version}</version>
+    <version>${aws-support-spring-boot-starter.version}</version>
 </dependency>
 ```
 
@@ -28,7 +28,7 @@ Add the following to your `pom.xml`
 Add the following to your `build.gradle`
 
 ```
-compile('org.zalando:aws-support-spring-boot-starter:$version')
+compile('org.zalando:aws-support-spring-boot-starter:$aws-support-spring-boot-starter.version')
 ```
 
 ### Download


### PR DESCRIPTION
This most likely does not need to be fixed I think.

In https://github.com/zalando/spring-cloud-config-aws-kms the version in the readme is the $project-name followed by .version.

When configuring the library for a system at work, noticed I created the variable first in my pom.xml, then copy/pasted the dependency from the README and it failed to build due to the variable mismatch.

Happy if this is closed as won't fix :-)

Thanks
Bruno

ps: deployed in one of our systems, working like a charm, and the kms library doesn't need any bootstrap.yml any more, unless you encrypt something.